### PR TITLE
Bug fix on signout

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -49,7 +49,8 @@ const onChangePassSuccess = function () {
 
 const onSignOutSuccess = function () {
   store.user = null
-  console.log(store.user)
+  store.game = null
+  // console.log(store.user)
   $('#change-password').toggle()
   $('#sign-out').toggle()
   $('#sign-in').toggle()


### PR DESCRIPTION
store.game was not getting cleared on sign out, causing the last game to
still be in memeory when a user logs back in.